### PR TITLE
[bugfix] - do not treat a 204 No Content as an error

### DIFF
--- a/zego/api.go
+++ b/zego/api.go
@@ -93,7 +93,8 @@ func api(auth Auth, meth string, path string, params string) (*Resource, error) 
 		return nil, err
 	}
 
-	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+	code := resp.StatusCode
+	if code >= 400 && code <= 499 || code >= 500 && code <= 599 {
 		singleError := &SingleError{}
 		err = json.Unmarshal(data, singleError)
 		if err == nil {


### PR DESCRIPTION
Inverts the status code checking to return an error if a 4xx or 5xx response status is returned.
